### PR TITLE
Fix 'parallel_requests' example

### DIFF
--- a/examples/parallel_requests.php
+++ b/examples/parallel_requests.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 use GuzzleHttp\Promise\Utils;
 use Instagram\SDK\Instagram;
-
-declare(strict_types=1);
 
 require_once __DIR__ . '/../vendor/autoload.php';
 


### PR DESCRIPTION
Fix '[parallel_requests](https://github.com/NicklasWallgren/instagram-api/blob/master/examples/parallel_requests.php)' example

` strict_types ` declaration must be the very first statement in the script
